### PR TITLE
xkingdom: document XCrown fields

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -3,6 +3,8 @@
 
 #include "common.h"
 
+#define SECTOR_SIZE (2048)
+
 typedef struct KingdomFile {
     /* 0x00 */ s32 hash;
     /* 0x04 */ s32 isCompressed;


### PR DESCRIPTION
I documented these fields based on the notes I had stored from my old archive. I can tell the I/O system in KH1 in asynchronous. What it is called here `XCrown` it is a task that spins a disk read operation to not block the rest of the game engine while waiting for the disc driver.

I am very new to this decomp. So please let me know what I have to adjust to respect the naming convention and if there are any PR standards I need to be aware of. I am leaving the _allow edits by maintainer_ enabled.