### PR TITLE
xkingdom: func_0011FFB8 matching

### DIFF
--- a/src/xkingdom.c
+++ b/src/xkingdom.c
@@ -107,8 +107,12 @@ s32 func_0011FF40(char* str) {
     return hash;
 }
 
-INCLUDE_ASM(const s32, "xkingdom", func_0011FFB8);
-UNK_RET func_0011FFB8(UNK_ARGS);
+// hash comparer for the binary search
+int func_0011FFB8(const int *left, const int *right) {
+    if (left < *right)
+        return -1;
+    return *right < left;
+}
 
 KingdomFile* func_0011FFD8(char* filename) {
     return bsearch(func_0011FF40(filename), &D_004DE140, D_002C2180, 0x10, func_0011FFB8);

--- a/src/xkingdom.c
+++ b/src/xkingdom.c
@@ -108,7 +108,7 @@ s32 func_0011FF40(char* str) {
 }
 
 // hash comparer for the binary search
-int func_0011FFB8(const int *left, const int *right) {
+int func_0011FFB8(const s32* left, const s32* right) {
     if (left < *right)
         return -1;
     return *right < left;


### PR DESCRIPTION
Pretty basic function to introduce myself into this decomp. This function is used as a hash comparison while performing a binary search in the hashed file list. My scratch is located here: https://decomp.me/scratch/NCWpo

Before merging, please let me know if I can rename the function. I've been thinking something like `hash_comparer`, which will help to remove the comment I added.