### PR TITLE
Added PCSX2 symbol tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ SLPS_251.05*
 *.o
 ctx.c
 ctx.c.m2c
+
+*.sym

--- a/tools/sym2pcsx2.py
+++ b/tools/sym2pcsx2.py
@@ -1,0 +1,63 @@
+# A simple tool that reads the symbol_addrs.txt file produced by Splat
+# and generates a .sym file for use with the PCSX2 emulator's debugger.
+
+# NOTE: The generated .sym file MUST be in the EXACT same directory and have
+# the EXACT same name as the .iso being used in PCSX2 for the emulator
+# to detect it. For example, the sym file generated to accompany
+# `Roms/KingdomHearts.iso` MUST be named/stored as `Roms/KingdomHearts.sym`
+
+import os
+import argparse
+
+
+def generate_sym_file(input_file, output_file):
+    with open(input_file, "r") as txt_file:
+        lines = txt_file.readlines()
+
+    with open(output_file, "w") as sym_file:
+        for line in lines:
+            # Write section titles into the output
+            if line.startswith("//") and "=" not in line:
+                sym_file.write("\n")  # Separate by section
+                sym_file.write(line)
+            else:
+                # Split the line into segments, discarding unnecessary data
+                parts = line.split("=")
+
+                if len(parts) == 2:
+                    # Extract symbol name and bit address
+                    symbol_name = parts[0].strip()
+                    rest = parts[1].split(";")
+                    bit_address = rest[0].strip()[2:]  # Remove 0x prefix
+
+                    # Write the converted data to the output .sym file
+                    sym_file.write(f"{bit_address} {symbol_name}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Splat's symbol_addrs.txt file into a PCSX2-compatible symbol table"
+    )
+    parser.add_argument(
+        "output_file",
+        nargs="?",
+        default="RENAME_TO_GAME_ISO.sym",
+        help="Name of the game's ISO file. This must match or the emulator will not recognize it.",
+    )
+    args = parser.parse_args()
+
+    # Read symbol_addrs.txt from the root directory
+    symbol_addrs = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "../symbol_addrs.txt"
+    )
+
+    # Set the output file path, addending .sym if necessary
+    output_file = args.output_file
+    if not output_file.endswith(".sym"):
+        output_file += ".sym"
+
+    generate_sym_file(symbol_addrs, output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I made that janktastic tool I was talking about; it reads the contents from symbol_addrs.txt and writes a .sym file that PCSX2 will recognize. Many apologies if it's not fantastic, I'm not great with Python, but it seems to work quickly and reliably. 
At the moment it can accept an optional argument in the command line to rename the file, otherwise it makes it fairly obvious that it needs to be renamed. PCSX2 requires that the file has the exact same name as the ISO being loaded, or it will not read the symbol table from the .sym file.
The resulting file is generated in the root directory, from where it can be relocated into the same directory storing the ISO that PCSX2 is set up to load from. This .sym file must be in that same directory, or again, it will not read from it.