### PR TITLE
xberry & ppp work

### DIFF
--- a/include/ppp.h
+++ b/include/ppp.h
@@ -28,6 +28,10 @@ typedef struct {
 
 extern sceVu0FVECTOR ppvParScl;
 
+// todo: find what this is, maybe KeLnsLp, but used extensively for non-KeLns stuff
+// symbol name is possibly a debug thing from 2.5 proto and will need renamed here
+extern UNK_TYPE ppvDbgTemp; 
+
 extern ppvmng* ppvMng;
 extern void* ppvEnv;
 extern pppPObject ppvPObj;

--- a/include/ppp/pppKeLns.h
+++ b/include/ppp/pppKeLns.h
@@ -1,0 +1,78 @@
+#ifndef PPPKELNS_H
+#define PPPKELNS_H
+
+#include "common.h"
+#include "ppp.h"
+
+// todo: relocate this once we have a better idea of what it is
+typedef struct {
+    /* 0x0 */ u_long128* shape;
+    /* 0x4 */ s32 nPacketSize;
+} pppShapeSt;
+
+typedef struct {
+    /* 0x00 */ FMATRIX mat;
+    /* 0x40 */ f32 zMat[3][4];
+    /* 0x70 */ f32 vec[2];
+    /* 0x78 */ f32 pers;
+    /* 0x7C */ f32 vPow;
+    /* 0x80 */ f32 lcPos[3];
+    /* 0x8C */ u8 idx;
+    /* 0x8D */ u8 mbk;
+    /* 0x8E */ u8 r;
+    /* 0x8F */ u8 md;
+    /* 0x90 */ sceVu0FVECTOR lVec;
+    /* 0xA0 */ f32 _p2[1];
+    /* 0xA4 */ f32 len2;
+    /* 0xA8 */ f32 pow;
+    /* 0xAC */ f32 preHidePow;
+} KeLnsLp; // size = 0xB0
+
+typedef struct {
+    /* 0x0 */ s16 cnt;
+    /* 0x2 */ u8 seqIdx;
+    /* 0x3 */ char flag[1];
+} KeLnsFlr; // size = 0x4
+
+typedef struct {
+    /* 0x0 */ KeLnsFlr* lp;
+    /* 0x4 */ pppShapeSt* shp;
+    /* 0x8 */ KeLnsFlr flr;
+} KeLnsArnd; // size = 0xC
+
+typedef struct {
+    /* 0x0 */ KeLnsFlr* lp;
+    /* 0x4 */ pppShapeSt* shp;
+    /* 0x8 */ KeLnsFlr flr;
+} KeLnsCrn; // size = 0xC
+
+typedef struct {
+    /* 0x0 */ KeLnsFlr* lp;
+    /* 0x4 */ pppShapeSt* shp;
+    /* 0x8 */ KeLnsFlr flr;
+} KeLnsFls; // size = 0xC
+
+typedef struct {
+    /* 0x0 */ KeLnsFlr flr;
+    /* 0x4 */ f32 rdPr;
+} KeLnsClmFlr; // size = 0x8
+
+typedef struct {
+    /* 0x00 */ KeLnsLp* lp;
+    /* 0x04 */ pppShapeSt* shp;
+    /* 0x08 */ u8 num;
+    /* 0x09 */ u8 flag;
+    /* 0x0A */ s16 betw;
+    /* 0x0C */ s16 stOfs;
+    /* 0x0E */ u8 flagType;
+    /* 0x0F */ char _p0[1];
+    /* 0x10 */ KeLnsClmFlr flr[1];
+} KeLnsClm; // size = 0x18
+
+void KeLnsLp_Init(KeLnsLp*);
+void KeLnsClm_Init(KeLnsClm*);
+void KeLnsArnd_Init(KeLnsArnd*);
+void KeLnsCrn_Init(KeLnsCrn*);
+void KeLnsFls_Init(KeLnsFls*);
+
+#endif // PPPKELNS_H

--- a/include/ppp/pppUtil.h
+++ b/include/ppp/pppUtil.h
@@ -1,0 +1,17 @@
+#ifndef PPPUTIL_H
+#define PPPUTIL_H
+
+#include "common.h"
+#include "ppp/pppKeLns.h"
+
+void pppGetRotMatrixX(sceVu0FMATRIX mp, u32 angle);
+void pppGetRotMatrixY(sceVu0FMATRIX mp, u32 angle);
+void pppGetRotMatrixZ(sceVu0FMATRIX mp, u32 angle);
+void pppGetRotMatrixXYZ(sceVu0FMATRIX mp, pppIVECTOR* angle);
+void pppGetRotMatrixXZY(sceVu0FMATRIX mp, pppIVECTOR* angle);
+void pppGetRotMatrixYZX(sceVu0FMATRIX mp, pppIVECTOR* angle);
+void pppGetRotMatrixYXZ(sceVu0FMATRIX mp, pppIVECTOR* angle);
+void pppGetRotMatrixZXY(sceVu0FMATRIX mp, pppIVECTOR* angle);
+void pppGetRotMatrixZYX(sceVu0FMATRIX arg0, pppIVECTOR* angle);
+
+#endif // PPPUTIL_H

--- a/src/ppp/pppKeAccSpdSv.c
+++ b/src/ppp/pppKeAccSpdSv.c
@@ -1,4 +1,4 @@
-#include "ppp.h"
+#include "ppp/pppUtil.h"
 
 void pppKeAccSpdSvCalc(void) {
 }
@@ -6,12 +6,12 @@ void pppKeAccSpdSvCalc(void) {
 void pppKeAccSpdSvCon(void) {
 }
 
-void func_001851E8(sceVu0FMATRIX arg0, u32* arg1) {
+void pppGetRotMatrixXYZ(sceVu0FMATRIX mp, pppIVECTOR* angle) {
     sceVu0FMATRIX m0, m1, m2, m3;
 
-    func_001A70F8(m0, arg1[2]);
-    func_001A7078(m1, arg1[1]);
+    pppGetRotMatrixZ(m0, angle->z);
+    pppGetRotMatrixY(m1, angle->y);
     sceVu0MulMatrix(m2, m0, m1);
-    func_001A6FF8(m3, arg1[0]);
-    sceVu0MulMatrix(arg0, m2, m3);
+    pppGetRotMatrixX(m3, angle->x);
+    sceVu0MulMatrix(mp, m2, m3);
 }

--- a/src/ppp/pppKeLnsArnd.c
+++ b/src/ppp/pppKeLnsArnd.c
@@ -1,7 +1,11 @@
-#include "ppp.h"
+#include "ppp/pppKeLns.h"
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsArnd", pppKeLnsArndDraw);
 
-INCLUDE_ASM(const s32, "ppp/pppKeLnsArnd", pppKeLnsArndCon);
+void pppKeLnsArndCon(pppPObject* pobj, pppCtrlTable* ctbl) {
+    KeLnsArnd* arnd = (KeLnsArnd*)&pobj->val[ctbl->useVal[0]];
+    
+    KeLnsArnd_Init(arnd);
+}
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsArnd", func_00193BC8);

--- a/src/ppp/pppKeLnsClm.c
+++ b/src/ppp/pppKeLnsClm.c
@@ -1,7 +1,12 @@
-#include "ppp.h"
+#include "ppp/pppKeLns.h"
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsClm", pppKeLnsClmDraw);
 
-INCLUDE_ASM(const s32, "ppp/pppKeLnsClm", pppKeLnsClmCon);
+void pppKeLnsClmCon(pppPObject* pobj, pppCtrlTable* ctbl) {
+    KeLnsClm* clm = (KeLnsClm*)&pobj->val[ctbl->useVal[0]];
+    
+    KeLnsClm_Init(clm);
+    clm->num = 4;
+}
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsClm", func_00193E80);

--- a/src/ppp/pppKeLnsCrn.c
+++ b/src/ppp/pppKeLnsCrn.c
@@ -1,7 +1,11 @@
-#include "ppp.h"
+#include "ppp/pppKeLns.h"
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsCrn", pppKeLnsCrnDraw);
 
-INCLUDE_ASM(const s32, "ppp/pppKeLnsCrn", pppKeLnsCrnCon);
+void pppKeLnsCrnCon(pppPObject* pobj, pppCtrlTable* ctbl) {
+    KeLnsCrn* crn = (KeLnsCrn*)&pobj->val[ctbl->useVal[0]];
+
+    KeLnsCrn_Init(crn);
+}
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsCrn", func_001940F0);

--- a/src/ppp/pppKeLnsFls.c
+++ b/src/ppp/pppKeLnsFls.c
@@ -1,9 +1,11 @@
-#include "ppp.h"
+#include "ppp/pppKeLns.h"
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsFls", pppKeLnsFlsDraw);
 
 void pppKeLnsFlsCon(pppPObject* pobj, pppCtrlTable* ctbl) {
-    KeLnsFls_Init(&pobj->val[ctbl->useVal[0]]);
+    KeLnsFls* fls = (KeLnsFls*)&pobj->val[ctbl->useVal[0]];
+    
+    KeLnsFls_Init(fls);
 }
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsFls", func_00194350);

--- a/src/ppp/pppKeLnsLp.c
+++ b/src/ppp/pppKeLnsLp.c
@@ -1,9 +1,28 @@
-#include "ppp.h"
+#include "ppp/pppKeLns.h"
+
+typedef struct {
+    /* 0x0 */ pppCDT cdt;
+    /* 0x4 */ f32 lWid;
+    /* 0x8 */ f32 pow;
+    /* 0xC */ u8 r;
+    /* 0xD */ u8 md;
+} PKeLnsLp;
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsLp", pppKeLnsLpDraw);
 
-INCLUDE_ASM(const s32, "ppp/pppKeLnsLp", pppKeLnsLpCon);
+void pppKeLnsLpCon(pppPObject* pobj, pppCtrlTable* ctbl) {
+    KeLnsLp* lp = (KeLnsLp*)&pobj->val[ctbl->useVal[0]];
 
-INCLUDE_ASM(const s32, "ppp/pppKeLnsLp", pppKeLnsLpCon2);
+    KeLnsLp_Init(lp);
+    lp->lVec[3] = 0;
+    lp->pow = 0;
+}
+
+void pppKeLnsLpCon2(pppPObject* pobj, pppCtrlTable* ctbl) {
+    KeLnsLp* lp = (KeLnsLp*)&pobj->val[ctbl->useVal[0]];
+
+    lp->lVec[3] = 0;
+    lp->pow = 0;
+}
 
 INCLUDE_ASM(const s32, "ppp/pppKeLnsLp", func_00193978);

--- a/src/xberry.c
+++ b/src/xberry.c
@@ -1,22 +1,129 @@
 #include "common.h"
 
-INCLUDE_ASM(const s32, "xberry", func_001A6FF8);
+#include "ppp/pppUtil.h"
+#include "ppp/pppKeLns.h"
 
-INCLUDE_ASM(const s32, "xberry", func_001A7078);
+#include "libvu0.h"
 
-INCLUDE_ASM(const s32, "xberry", func_001A70F8);
+extern f32 D_0036F790[0x1000]; // sine table
 
-INCLUDE_ASM(const s32, "xberry", func_001A7178);
+void pppGetRotMatrixX(sceVu0FMATRIX mp, u32 angle) {
+    f32 sin = D_0036F790[(angle / 16) % 0x1000];
+    f32 cos = D_0036F790[((angle + 0x4000) / 16) % 0x1000];
 
-INCLUDE_ASM(const s32, "xberry", func_001A7208);
+    mp[0][0] = 1.0f;
+    mp[1][0] = 0.0f;
+    mp[2][0] = 0.0f;
+    mp[3][0] = 0.0f;
+    mp[0][1] = 0.0f;
+    mp[1][1] = cos;
+    mp[2][1] = -sin;
+    mp[3][1] = 0.0f;
+    mp[0][2] = 0.0f;
+    mp[1][2] = sin;
+    mp[2][2] = cos;
+    mp[3][2] = 0.0f;
+    mp[0][3] = 0.0f;
+    mp[1][3] = 0.0f;
+    mp[2][3] = 0.0f;
+    mp[3][3] = 1.0f;
+}
 
-INCLUDE_ASM(const s32, "xberry", func_001A7298);
+void pppGetRotMatrixY(sceVu0FMATRIX mp, u32 angle) {
+    f32 sin = D_0036F790[(angle / 16) % 0x1000];
+    f32 cos = D_0036F790[((angle + 0x4000) / 16) % 0x1000];
 
-INCLUDE_ASM(const s32, "xberry", func_001A7328);
+    mp[0][0] = cos;
+    mp[1][0] = 0.0f;
+    mp[2][0] = sin;
+    mp[3][0] = 0.0f;
+    mp[0][1] = 0.0f;
+    mp[1][1] = 1.0f;
+    mp[2][1] = 0.0f;
+    mp[3][1] = 0.0f;
+    mp[0][2] = -sin;
+    mp[1][2] = 0.0f;
+    mp[2][2] = cos;
+    mp[3][2] = 0.0f;
+    mp[0][3] = 0.0f;
+    mp[1][3] = 0.0f;
+    mp[2][3] = 0.0f;
+    mp[3][3] = 1.0f;
+}
 
-INCLUDE_ASM(const s32, "xberry", func_001A73B8);
+void pppGetRotMatrixZ(sceVu0FMATRIX mp, u32 angle) {
+    f32 sin = D_0036F790[(angle / 16) % 0x1000];
+    f32 cos = D_0036F790[((angle + 0x4000) / 16) % 0x1000];
 
-INCLUDE_ASM(const s32, "xberry", func_001A7448);
+    mp[0][0] = cos;
+    mp[1][0] = -sin;
+    mp[2][0] = 0.0f;
+    mp[3][0] = 0.0f;
+    mp[0][1] = sin;
+    mp[1][1] = cos;
+    mp[2][1] = 0.0f;
+    mp[3][1] = 0.0f;
+    mp[0][2] = 0.0f;
+    mp[1][2] = 0.0f;
+    mp[2][2] = 1.0f;
+    mp[3][2] = 0.0f;
+    mp[0][3] = 0.0f;
+    mp[1][3] = 0.0f;
+    mp[2][3] = 0.0f;
+    mp[3][3] = 1.0f;
+}
+
+void pppGetRotMatrixXZY(sceVu0FMATRIX mp, pppIVECTOR* angle) {
+    sceVu0FMATRIX m0, m1, m2, m3;
+
+    pppGetRotMatrixY(m0, angle->y);
+    pppGetRotMatrixZ(m1, angle->z);
+    sceVu0MulMatrix(m2, m0, m1);
+    pppGetRotMatrixX(m3, angle->x);
+    sceVu0MulMatrix(mp, m2, m3);
+}
+
+void pppGetRotMatrixYZX(sceVu0FMATRIX mp, pppIVECTOR* angle) {
+    sceVu0FMATRIX m0, m1, m2, m3;
+
+    pppGetRotMatrixX(m0, angle->x);
+    pppGetRotMatrixZ(m1, angle->z);
+    sceVu0MulMatrix(m2, m0, m1);
+    pppGetRotMatrixY(m3, angle->y);
+    sceVu0MulMatrix(mp, m2, m3);
+}
+
+void pppGetRotMatrixYXZ(sceVu0FMATRIX mp, pppIVECTOR* angle) {
+    sceVu0FMATRIX m0, m1, m2, m3;
+
+    pppGetRotMatrixZ(m0, angle->z);
+    pppGetRotMatrixX(m1, angle->x);
+    sceVu0MulMatrix(m2, m0, m1);
+    pppGetRotMatrixY(m3, angle->y);
+    sceVu0MulMatrix(mp, m2, m3);
+}
+
+void pppGetRotMatrixZXY(sceVu0FMATRIX mp, pppIVECTOR* angle) {
+    sceVu0FMATRIX m0, m1, m2, m3;
+
+    pppGetRotMatrixY(m0, angle->y);
+    pppGetRotMatrixX(m1, angle->x);
+    sceVu0MulMatrix(m2, m0, m1);
+    pppGetRotMatrixZ(m3, angle->z);
+    sceVu0MulMatrix(mp, m2, m3);
+}
+
+void pppGetRotMatrixZYX(sceVu0FMATRIX arg0, pppIVECTOR* angle) {
+    sceVu0FMATRIX m0, m1, m2, m3;
+
+    pppGetRotMatrixX(m0, angle->x);
+    pppGetRotMatrixY(m1, angle->y);
+    sceVu0MulMatrix(m2, m0, m1);
+    pppGetRotMatrixZ(m3, angle->z);
+    sceVu0MulMatrix(arg0, m2, m3);
+}
+
+INCLUDE_ASM(const s32, "xberry", KeBornRnd2);
 
 INCLUDE_ASM(const s32, "xberry", func_001A75B0);
 
@@ -26,26 +133,43 @@ INCLUDE_ASM(const s32, "xberry", func_001A7668);
 
 INCLUDE_ASM(const s32, "xberry", func_001A76E8);
 
-INCLUDE_ASM(const s32, "xberry", func_001A7BF8);
+void KeLnsLp_Init(KeLnsLp* lp) {
+    ppvMng->drawPriority = 2;
+    sceVu0UnitMatrix(lp->zMat);
+    lp->preHidePow = 1.0f;
+}
 
 INCLUDE_ASM(const s32, "xberry", func_001A7C40);
 
 INCLUDE_ASM(const s32, "xberry", func_001A7F48);
 
-INCLUDE_ASM(const s32, "xberry", func_001A8048);
+void KeLnsClm_Init(KeLnsClm* p) {
+    p->flag = 0;
+    p->lp = &ppvDbgTemp;
+    p->shp = NULL;
+}
 
 INCLUDE_ASM(const s32, "xberry", func_001A8060);
 
-INCLUDE_ASM(const s32, "xberry", func_001A8230);
+void KeLnsArnd_Init(KeLnsArnd* p) {
+    p->shp = NULL;
+    p->lp = &ppvDbgTemp;
+}
 
 INCLUDE_ASM(const s32, "xberry", func_001A8248);
 
 INCLUDE_ASM(const s32, "xberry", func_001A84B8);
 
-INCLUDE_ASM(const s32, "xberry", func_001A84D8);
+void KeLnsCrn_Init(KeLnsCrn* p) {
+    p->shp = NULL;
+    p->lp = &ppvDbgTemp;
+}
 
 INCLUDE_ASM(const s32, "xberry", KeLnsFls_Draw);
 
-INCLUDE_ASM(const s32, "xberry", KeLnsFls_Init);
+void KeLnsFls_Init(KeLnsFls* p) {
+    p->shp = NULL;
+    p->lp = &ppvDbgTemp;
+}
 
 INCLUDE_ASM(const s32, "xberry", func_001A8770);

--- a/symbol_addrs.txt
+++ b/symbol_addrs.txt
@@ -59,6 +59,7 @@ pppKeThCpSftCalc             = 0x001851D0; // type:func
 // pppKeAccSpdSv.c
 pppKeAccSpdSvCalc            = 0x001851D8; // type:func
 pppKeAccSpdSvCon             = 0x001851E0; // type:func
+pppGetRotMatrixXYZ           = 0x001851E8; // type:func
 
 // pppDrawHook.c
 pppDrawHookDraw              = 0x00185278; // type:func
@@ -878,10 +879,23 @@ pppRyjMegaBirthModelFilterSta = 0x001A6EF8; // type:func
 pppRyjMegaBirthModelFilterCon = 0x001A6F50; // type:func
 pppRyjMegaBirthModelFilterDes = 0x001A6F98; // type:func
 
-KeThResHd_Init               = 0x001AA960; // type:func
-
+/// xberry.c
+pppGetRotMatrixX             = 0x001A6FF8; // type:func
+pppGetRotMatrixY             = 0x001A7078; // type:func
+pppGetRotMatrixZ             = 0x001A70F8; // type:func
+pppGetRotMatrixXZY           = 0x001A7178; // type:func
+pppGetRotMatrixYZX           = 0x001A7208; // type:func
+pppGetRotMatrixYXZ           = 0x001A7298; // type:func
+pppGetRotMatrixZXY           = 0x001A7328; // type:func
+pppGetRotMatrixZYX           = 0x001A73B8; // type:func
+KeBornRnd2                   = 0x001A7448; // type:func
+KeLnsLp_Init                 = 0x001A7BF8; // type:func
+KeLnsClm_Init                = 0x001A8048; // type:func
+KeLnsArnd_Init               = 0x001A8230; // type:func
+KeLnsCrn_Init                = 0x001A84D8; // type:func
 KeLnsFls_Draw                = 0x001A84F0; // type:func
 KeLnsFls_Init                = 0x001A8758; // type:func
+KeThResHd_Init               = 0x001AA960; // type:func
 
 //=============================
 // disk.c
@@ -2043,6 +2057,7 @@ cdvd_CbThreadStack           = 0x004ECCF0; // size:0x1000
 //=============================
 // ppp lib
 //=============================
+ppvDbgTemp                   = 0x00570140;
 ppvMng                       = 0x006105A0;
 ppvEnv                       = 0x006105A4;
 ppvPObj                      = 0x006105A8;


### PR DESCRIPTION
Few quirks
-  ppvDbgTemp sounds like "debug temp", it's a symbol from the 2.5 prototype and reasonably is named differently here
- several overarching concepts throughout the ppp library reference an "Lp" structure of some sort located at ppvDbgTemp, though they seem to vary in makeup. 
- Almost every "pppGetRotMatrix" function is inside of xberry, except XYZ, which ended up in pppKeAccSpdSv
- pppShapeSt is used in a few different places, possibly a wrapper around models or something. As more usage is uncovered, we should move it somewhere more centralized.