### PR TITLE
Take laser away from kitten, clean up after it

### DIFF
--- a/include/memcard.h
+++ b/include/memcard.h
@@ -1,6 +1,7 @@
 #include "common.h"
 
 void memcard_Initialize(void);
+void memcard_SetDefaults(void);
 
 s32 memcard_GetAllStatus(void);
 s32 memcard_GetDirStatus(void);

--- a/include/xmeowp.h
+++ b/include/xmeowp.h
@@ -23,6 +23,7 @@ typedef struct XKitten {
     /* 0x7C */ s32 unk_7C;
     /* 0x80 */ s32 unk_80;
     /* 0x84 */ s32 unk_84;
+    /* 0x88 */ char unk_88[0x60];
 } XKitten;
 
 XKitten* func_001F3A20(XKitten*, s32);

--- a/include/xmeowp.h
+++ b/include/xmeowp.h
@@ -1,0 +1,44 @@
+#include "common.h"
+
+typedef struct XLaserDot {
+    u8 unk[16];
+} XLaserDot;
+
+typedef struct XKitten {
+    /* 0x00 */ s32 unk_00;
+    /* 0x04 */ s32 unk_04;
+    /* 0x04 */ s32 unk_08;
+    /* 0x0C */ struct XKitten* prev;
+    /* 0x10 */ struct XKitten* next;
+    /* 0x14 */ struct XKitten* prev_kit;
+    /* 0x18 */ struct XKitten* next_kit;
+    /* 0x1C */ u8 unk_1C[28];
+    /* 0x38 */ u64 unk_38;
+    /* 0x40 */ u8 unk_40[28];
+    /* 0x5C */ XLaserDot* unk_5C;
+    /* 0x60 */ u8 unk_60[8];
+    /* 0x68 */ s32 unk_68;
+    /* 0x6C */ u8 unk_6C[12];
+    /* 0x78 */ s32 unk_78;
+    /* 0x7C */ s32 unk_7C;
+    /* 0x80 */ s32 unk_80;
+    /* 0x84 */ s32 unk_84;
+} XKitten;
+
+XKitten* func_001F3A20(XKitten*, s32);
+void func_001F3DA0(XKitten*, s32);
+void func_001F3EC8(XKitten*);
+void func_001F3F00(XKitten*);
+void func_001F3F18(XKitten*, s32);
+s32 func_001F3F38(XKitten*);
+s32 func_001F3F88(XKitten*, s32);
+s32 func_001F3FD8(XKitten*);
+s32 func_001F4040(XKitten*, s32);
+s32 func_001F40C0(XKitten*);
+void func_001F45D8(XKitten*, s32);
+void func_001F45F0(XKitten*);
+void func_001F4640(XKitten*);
+void func_001F4668(XKitten*, XKitten*);
+void func_001F4690(XKitten*, XKitten*);
+void func_001F46D8(XKitten*, XKitten*);
+void func_001F4888(XKitten*, s32);

--- a/include/xmeowp.h
+++ b/include/xmeowp.h
@@ -1,9 +1,5 @@
 #include "common.h"
 
-typedef struct XLaserDot {
-    u8 unk[16];
-} XLaserDot;
-
 typedef struct XKitten {
     /* 0x00 */ s32 unk_00;
     /* 0x04 */ s32 unk_04;
@@ -15,7 +11,7 @@ typedef struct XKitten {
     /* 0x1C */ u8 unk_1C[28];
     /* 0x38 */ u64 unk_38;
     /* 0x40 */ u8 unk_40[28];
-    /* 0x5C */ XLaserDot* unk_5C;
+    /* 0x5C */ u8* unk_5C;
     /* 0x60 */ u8 unk_60[8];
     /* 0x68 */ s32 unk_68;
     /* 0x6C */ u8 unk_6C[12];

--- a/kh.jp.yaml
+++ b/kh.jp.yaml
@@ -286,7 +286,7 @@ segments:
     - [0xEED88, asm]
     - [0xEF290, c, xtango]
     - [0xF0CB0, c, xbiscuit]
-    - [0xF3AA0, c, xmeowp]
+    - [0xF3A10, c, xmeowp]
     - [0xF4910, asm]
     - [0x115B08, c, xpotato]
     - [0x119868, c, xrodent]

--- a/kh.jp.yaml
+++ b/kh.jp.yaml
@@ -546,7 +546,8 @@ segments:
     - [0x387A60, rodata, 3BE08]
     - [0x3881C0, rodata, 4A098]
     - [0x389BC0, rodata, DF218]
-    - [0x38A700, .rodata, xmeowp]
+    # - [0x38A610, .rodata, xbiscuit] # todo: switch tables
+    - [0x38A6F0, .rodata, xmeowp]
     - [0x38A720, rodata, F4910]
     - [0x38AB30, .rodata, xrodent]
     - [0x38AB50, rodata, 11A450]

--- a/src/xbiscuit.c
+++ b/src/xbiscuit.c
@@ -1,12 +1,6 @@
 #include "common.h"
 #include "libdma.h"
 
-typedef struct {
-    /* 0x00 */ char unk_00[0x84];
-    /* 0x84 */ s32 unk_84;
-    /* 0x88 */ char unk_88[0x60];
-} XCookie;
-
 extern s32 D_003DEF90;
 extern s32 D_003E0810;
 extern s32 D_003E2BE0;
@@ -14,8 +8,6 @@ extern s32 D_003E3080;
 extern s32 D_003E3084;
 extern s32* D_003E30A8;
 extern s32 D_003E30AC;
-extern s32 D_003EBCC0;
-extern s32 D_003EBCC4;
 extern s32 D_003E38C0;
 extern s32 D_003EB8C0;
 
@@ -23,7 +15,6 @@ extern s32 D_00639A80;
 extern s32* D_00639A84;
 extern s32* D_00639A88;
 extern s32 D_00639A8C;
-XCookie D_00639A90[24];
 extern void* D_0063B050;
 
 void func_001F0DF8(s32*, s32*);
@@ -259,28 +250,3 @@ void func_001F3718(s32** arg0, s32** arg1) {
 }
 
 INCLUDE_ASM(const s32, "xbiscuit", func_001F3738);
-
-// Nonmatch: Assignment instructions out of order
-INCLUDE_ASM(const s32, "xbiscuit", func_001F3990);
-// void func_001F3990(void) {
-//     s32 i = 24;
-//     XCookie* cookie = D_00639A90;
-
-//     while (0 < i) {
-//         cookie->unk_84 = 0;
-//         cookie++;
-//         i--;
-//     }
-
-//     D_0063B050 = NULL;
-//     D_003EBCC0 = 0x80E6E6E6;
-//     D_003EBCC4 = 0x140;
-
-//     func_001F0E58(8);
-//     func_001F0E58(0);
-//     func_001FDAC8();
-// }
-
-s32 func_001F3A08(void* arg0) {
-    return func_001F3A20(arg0, 6);
-}

--- a/src/xbiscuit.c
+++ b/src/xbiscuit.c
@@ -11,6 +11,8 @@ extern s32 D_003E30AC;
 extern s32 D_003E38C0;
 extern s32 D_003EB8C0;
 
+char D_0048A590[32]; // "menu/sysfont.bin"
+
 extern s32 D_00639A80;
 extern s32* D_00639A84;
 extern s32* D_00639A88;
@@ -22,7 +24,30 @@ void* func_001F1960(s32, s32, s32, s32, s32, s32, s32, s32);
 void* func_001F19F0(s32, s32, s32, s32, s32, s32, s32, s32);
 void* func_001F1FA8(s32, s32, s32, s32, s32, s32, s32, s32);
 
-INCLUDE_ASM(const s32, "xbiscuit", func_001F0C30);
+void func_001F0C30(void) {
+    void* dst;
+    u64 stack0[22];
+    u64 stack1[22];
+
+    dst = func_00155ED8(0x34, 12);
+
+    func_00120438(D_0048A590, dst);
+
+    func_0011F9E8(0x3FFC, 1, 0, 0, 0, 0x10, 0x10, 0x40, dst + 0x10000, stack1);
+    FlushCache(0);
+    sceDmaSend(sceDmaGetChan(SCE_DMA_GIF), stack1);
+    sceGsSyncPath(0, 0);
+
+    func_0011F9E8(0x1000, 4, 36, 0, 0, 0x100, 0x100, 0x800, dst, stack0);
+    FlushCache(0);
+    sceDmaSend(sceDmaGetChan(SCE_DMA_GIF), stack0);
+    sceGsSyncPath(0, 0);
+
+    func_0011F9E8(0x1000, 4, 44, 0, 0, 0x100, 0x100, 0x800, dst + 0x8000, stack0);
+    FlushCache(0);
+    sceDmaSend(sceDmaGetChan(SCE_DMA_GIF), stack0);
+    sceGsSyncPath(0, 0);
+}
 
 // Nonmatch: Assignment instructions out of order
 INCLUDE_ASM(const s32, "xbiscuit", func_001F0D88);
@@ -190,7 +215,7 @@ INCLUDE_ASM(const s32, "xbiscuit", func_001F1FA8);
 
 INCLUDE_ASM(const s32, "xbiscuit", func_001F2378);
 
-void* func_001F2670(s32,s32,s32,s32,s32,s32,s32);
+void* func_001F2670(s32, s32, s32, s32, s32, s32, s32);
 INCLUDE_ASM(const s32, "xbiscuit", func_001F2670);
 
 void* func_001F2888(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5, s32 arg6) {

--- a/src/xmeowp.c
+++ b/src/xmeowp.c
@@ -1,93 +1,64 @@
 #include "common.h"
-
-typedef struct XLaserDot {
-    u8 unk[16];
-} XLaserDot;
-
-typedef struct XKitten {
-    /* 0x00 */ s32 unk_00;
-    /* 0x04 */ s32 unk_04;
-    /* 0x04 */ s32 unk_08;
-    /* 0x0C */ struct XKitten* prev;
-    /* 0x10 */ struct XKitten* next;
-    /* 0x14 */ struct XKitten* prev_kit;
-    /* 0x18 */ struct XKitten* next_kit;
-    /* 0x1C */ u8 unk_1C[28];
-    /* 0x38 */ u64 unk_38;
-    /* 0x40 */ u8 unk_40[28];
-    /* 0x5C */ XLaserDot* unk_5C;
-    /* 0x60 */ u8 unk_60[8];
-    /* 0x68 */ s32 unk_68;
-    /* 0x6C */ u8 unk_6C[12];
-    /* 0x78 */ s32 unk_78;
-    /* 0x7C */ s32 unk_7C;
-    /* 0x80 */ s32 unk_80;
-    /* 0x84 */ s32 unk_84;
-} XKitten;
-
-extern s32 func_00233138(s32, s32);
+#include "xmeowp.h"
 
 extern XKitten D_003E3890;
 extern void* D_003E3898;
 extern XLaserDot D_0048A670;
 extern XKitten* D_0063B050;
 
+extern s32 func_00233138(s32, s32);
+
 INCLUDE_ASM(XKitten*, "xmeowp", func_001F3A20);
 
-XKitten* func_001F3D50(void* param_1) {
-    s32 lVar1 = func_00233138(4, 54);
-    return (XKitten*)func_001F3A20(param_1, lVar1 + 1);
+XKitten* func_001F3D50(XKitten* arg0) {
+    return func_001F3A20(arg0, func_00233138(4, 54) + 1);
 }
 
-void func_001F3D88(void* param_1) {
-    func_001F3DA0(param_1, 6);
+void func_001F3D88(void* arg0) {
+    func_001F3DA0(arg0, 6);
 }
 
 INCLUDE_ASM(const s32, "xmeowp", func_001F3DA0);
 
-void func_001F3DF0(void* param_1) {
-    s32 iVar1 = func_00233138(4, 54);
-    func_001F3DA0(param_1, iVar1 + 1);
+void func_001F3DF0(void* arg0) {
+    func_001F3DA0(arg0, func_00233138(4, 54) + 1);
 }
 
-XKitten* func_001F3E28(s32 param_1, s32 param_2) {
-    D_003E3890.unk_00 = param_2;
-    D_003E3890.unk_08 = param_1;
-    return (XKitten*)func_001F3A20(&D_003E3890, 6);
+XKitten* func_001F3E28(s32 arg0, s32 arg1) {
+    D_003E3890.unk_00 = arg1;
+    D_003E3890.unk_08 = arg0;
+    return func_001F3A20(&D_003E3890, 6);
 }
 
-XKitten* func_001F3E58(s32 param1, s32 param2, s32 param3) {
-    D_003E3890.unk_00 = param2;
-    D_003E3890.unk_08 = param1;
-    return (XKitten*)func_001F3A20(&D_003E3890, param3);
+XKitten* func_001F3E58(s32 arg0, s32 arg1, s32 arg2) {
+    D_003E3890.unk_00 = arg1;
+    D_003E3890.unk_08 = arg0;
+    return func_001F3A20(&D_003E3890, arg2);
 }
 
-XKitten* func_001F3E88(s32 param1, s32 param2) {
-    s32 lVar1;
-
-    D_003E3890.unk_00 = param2;
-    D_003E3890.unk_08 = param1;
-    lVar1 = func_00233138(4, 0x36);
-    return (XKitten*)func_001F3A20(&D_003E3890, lVar1 + 1);
+XKitten* func_001F3E88(s32 arg0, s32 arg1) {
+    D_003E3890.unk_00 = arg1;
+    D_003E3890.unk_08 = arg0;
+    return func_001F3A20(&D_003E3890, func_00233138(4, 54) + 1);
 }
 
-void func_001F3EC8(XKitten* xkitten) {
-    xkitten->unk_84 = 4;
-    if (xkitten->prev) {
-        xkitten->prev->next = xkitten->next;
+void func_001F3EC8(XKitten* arg0) {
+    arg0->unk_84 = 4;
+    if (arg0->prev) {
+        arg0->prev->next = arg0->next;
     }
-    if (xkitten->next) {
-        xkitten->next->prev = xkitten->prev;
+    if (arg0->next) {
+        arg0->next->prev = arg0->prev;
     }
 }
 
-void func_001F3F00(XKitten* xkitten) {
-    xkitten->unk_38 |= 0x100000000;
+void func_001F3F00(XKitten* arg0) {
+    arg0->unk_38 |= 0x100000000;
 }
 
-void func_001F3F18(XKitten* xkitten, s32 param2) {
-    xkitten->unk_7C = param2;
-    xkitten->unk_38 |= 0x100000000;
+void func_001F3F18(XKitten* arg0, s32 arg1) {
+    arg0->unk_7C = arg1;
+    arg0->unk_38 |= 0x100000000;
 }
 
 INCLUDE_ASM(const s32, "xmeowp", func_001F3F38);
@@ -116,93 +87,108 @@ INCLUDE_ASM(const s32, "xmeowp", func_001F4510);
 
 INCLUDE_ASM(const s32, "xmeowp", func_001F4590);
 
-void func_001F45D8(XKitten* xkitten, s32 param2) {
-    xkitten->unk_7C = param2;
+void func_001F45D8(XKitten* arg0, s32 arg1) {
+    arg0->unk_7C = arg1;
 }
 
-void func_001F45E0(XKitten* xkitten) {
-    xkitten->unk_7C = xkitten->unk_78;
+void func_001F45E0(XKitten* arg0) {
+    arg0->unk_7C = arg0->unk_78;
 }
 
-void func_001F45F0(XKitten* xkitten) {
-    if (xkitten->prev_kit) {
-        xkitten->prev_kit->next_kit = xkitten->next_kit;
-        if (xkitten->next_kit == NULL) {
-            xkitten->prev_kit = NULL;
+void func_001F45F0(XKitten* arg0) {
+    if (arg0->prev_kit) {
+        arg0->prev_kit->next_kit = arg0->next_kit;
+        if (arg0->next_kit == NULL) {
+            arg0->prev_kit = NULL;
         } else {
-            xkitten->next_kit->prev_kit = xkitten->prev_kit;
-            xkitten->prev_kit = NULL;
+            arg0->next_kit->prev_kit = arg0->prev_kit;
+            arg0->prev_kit = NULL;
         }
-        xkitten->next_kit = D_0063B050;
-        D_0063B050->prev_kit = xkitten;
-        D_0063B050 = xkitten;
+        arg0->next_kit = D_0063B050;
+        D_0063B050->prev_kit = arg0;
+        D_0063B050 = arg0;
     }
 }
 
-void func_001F4640(XKitten* xkitten) {
-    if (xkitten) {
-        xkitten->unk_38 |= 0x200000000;
+void func_001F4640(XKitten* arg0) {
+    if (arg0) {
+        arg0->unk_38 |= 0x200000000;
     }
 }
 
-void func_001F4668(XKitten* xkitten, XKitten* prev) {
-    xkitten->prev = prev;
+void func_001F4668(XKitten* arg0, XKitten* prev) {
+    arg0->prev = prev;
 }
 
-void func_001F4670(XKitten* xkitten) {
-    if (xkitten->prev) {
-        xkitten->prev->next = NULL;
-        xkitten->prev = NULL;
+void func_001F4670(XKitten* arg0) {
+    if (arg0->prev) {
+        arg0->prev->next = NULL;
+        arg0->prev = NULL;
     }
 }
 
-void func_001F4690(XKitten* xkitten1, XKitten* xkitten2) {
-    XKitten *kit1, *kit2;
+void func_001F4690(XKitten* arg0, XKitten* arg1) {
+    XKitten* kit;
 
-    if (xkitten1->prev) {
-        xkitten1->prev->next = xkitten1->next;
-        kit1 = xkitten1->next;
-    } else {
-        kit1 = xkitten1->next;
+    if (arg0->prev != NULL) {
+        arg0->prev->next = arg0->next;
     }
 
-    if (kit1) {
-        kit1->prev = xkitten1->prev;
-        kit2 = xkitten2->next;
-    } else {
-        kit2 = xkitten2->next;
+    if (arg0->next != NULL) {
+        arg0->next->prev = arg0->prev;
     }
 
-    xkitten2->next = xkitten1;
-    xkitten1->prev = xkitten2;
-    xkitten1->next = kit2;
-    if (kit2 != NULL) {
-        kit2->prev = xkitten1;
+    kit = arg1->next;
+
+    arg1->next = arg0;
+    arg0->prev = arg1;
+    arg0->next = kit;
+    if (kit != NULL) {
+        kit->prev = arg0;
     }
 }
 
-void func_001F46D8(XKitten* xkitten, XKitten* next) {
-    xkitten->next = next;
+void func_001F46D8(XKitten* arg0, XKitten* next) {
+    arg0->next = next;
 }
 
-void func_001F46E0(XKitten* xkitten) {
-    if (xkitten->next) {
-        xkitten->next->prev = NULL;
-        xkitten->next = NULL;
+void func_001F46E0(XKitten* arg0) {
+    if (arg0->next) {
+        arg0->next->prev = NULL;
+        arg0->next = NULL;
     }
 }
 
-INCLUDE_ASM(const s32, "xmeowp", func_001F4700);
+void func_001F4700(XKitten* arg0, XKitten* arg1) {
+    XKitten* pXVar1;
+
+    if (arg0->prev != NULL) {
+        arg0->prev->next = arg0->next;
+    }
+
+    if (arg0->next != NULL) {
+        arg0->next->prev = arg0->prev;
+    }
+
+    pXVar1 = arg1->prev;
+
+    arg1->prev = arg0;
+    arg0->next = arg1;
+    arg0->prev = pXVar1;
+
+    if (pXVar1 != NULL) {
+        pXVar1->next = arg0;
+    }
+}
 
 INCLUDE_ASM(const s32, "xmeowp", func_001F4748);
 
 INCLUDE_ASM(const s32, "xmeowp", func_001F4790);
 
-void func_001F47F0(XKitten* xkitten) {
-    XKitten *prev, *next;
+void func_001F47F0(XKitten* arg0) {
+    XKitten* prev = arg0->prev;
+    XKitten* next = arg0->next;
 
-    prev = xkitten->prev;
-    next = xkitten->next;
     if (prev != NULL) {
         prev->next = next;
     }
@@ -211,47 +197,45 @@ void func_001F47F0(XKitten* xkitten) {
     }
 }
 
-void func_001F4810(XKitten* xkitten1, XKitten* xkitten2) {
-    XKitten *kit1_next, *kit1_prev, *kit2_next, *kit2_prev;
+void func_001F4810(XKitten* arg0, XKitten* arg1) {
+    XKitten* kit1_next = arg0->next;
+    XKitten* kit1_prev = arg0->prev;
+    XKitten* kit2_prev = arg1->prev;
+    XKitten* kit2_next = arg1->next;
 
-    kit1_next = xkitten1->next;
-    kit1_prev = xkitten1->prev;
-    kit2_prev = xkitten2->prev;
-    kit2_next = xkitten2->next;
     if (kit1_prev != NULL) {
-        kit1_prev->next = xkitten2;
+        kit1_prev->next = arg1;
     }
     if (kit1_next != NULL) {
-        kit1_next->prev = xkitten2;
+        kit1_next->prev = arg1;
     }
     if (kit2_prev != NULL) {
-        kit2_prev->next = xkitten1;
+        kit2_prev->next = arg0;
     }
     if (kit2_next != NULL) {
-        kit2_next->prev = xkitten1;
+        kit2_next->prev = arg0;
     }
-    xkitten1->prev = kit2_prev;
-    xkitten1->next = kit2_next;
-    xkitten2->prev = kit1_prev;
-    xkitten2->next = kit1_next;
+    arg0->prev = kit2_prev;
+    arg0->next = kit2_next;
+    arg1->prev = kit1_prev;
+    arg1->next = kit1_next;
 }
 
-XLaserDot* func_001F4858(XKitten* xkitten) {
-    XLaserDot* dot = xkitten->unk_5C;
-    if (dot == NULL) {
-        dot = &D_0048A670;
+XLaserDot* func_001F4858(XKitten* arg0) {
+    if (arg0->unk_5C == NULL) {
+        return &D_0048A670;
     }
-    return dot;
+    return arg0->unk_5C;
 }
 
-void func_001F4878(XKitten* xkitten, XLaserDot* dot) {
-    xkitten->unk_5C = dot;
+void func_001F4878(XKitten* arg0, XLaserDot* arg1) {
+    arg0->unk_5C = arg1;
 }
 
-s32 func_001F4880(XKitten* xkitten) {
-    return xkitten->unk_68;
+s32 func_001F4880(XKitten* arg0) {
+    return arg0->unk_68;
 }
 
-void func_001F4888(XKitten* xkitten, s32 param2) {
-    xkitten->unk_68 = param2;
+void func_001F4888(XKitten* arg0, s32 arg1) {
+    arg0->unk_68 = arg1;
 }

--- a/src/xmeowp.c
+++ b/src/xmeowp.c
@@ -3,10 +3,42 @@
 
 extern XKitten D_003E3890;
 extern void* D_003E3898;
+extern s32 D_003EBCC0;
+extern s32 D_003EBCC4;
+
 extern XLaserDot D_0048A670;
+
+extern XKitten D_00639A90[24];
 extern XKitten* D_0063B050;
 
 extern s32 func_00233138(s32, s32);
+
+// Nonmatch: Assignment instructions out of order
+INCLUDE_ASM(const s32, "xmeowp", func_001F3990);
+// void func_001F3990(void) {
+//     XKitten* pXVar1;
+//     int iVar2;
+
+//     iVar2 = 24;
+//     pXVar1 = D_00639A90;
+//     do {
+//         iVar2 += -1;
+//         pXVar1->unk_84 = 0;
+//         pXVar1 = pXVar1 + 1;
+//     } while (0 < iVar2);
+
+//     D_0063B050 = NULL;
+//     D_003EBCC0 = 0x80E6E6E6;
+//     D_003EBCC4 = 320;
+
+//     func_001F0E58(8);
+//     func_001F0E58(0);
+//     func_001FDAC8();
+// }
+
+s32 func_001F3A08(void* arg0) {
+    return func_001F3A20(arg0, 6);
+}
 
 INCLUDE_ASM(XKitten*, "xmeowp", func_001F3A20);
 

--- a/src/xmeowp.c
+++ b/src/xmeowp.c
@@ -6,7 +6,7 @@ extern void* D_003E3898;
 extern s32 D_003EBCC0;
 extern s32 D_003EBCC4;
 
-extern XLaserDot D_0048A670;
+const u8 D_0048A670[16] = {};
 
 extern XKitten D_00639A90[24];
 extern XKitten* D_0063B050;
@@ -36,7 +36,7 @@ INCLUDE_ASM(const s32, "xmeowp", func_001F3990);
 //     func_001FDAC8();
 // }
 
-s32 func_001F3A08(void* arg0) {
+XKitten* func_001F3A08(void* arg0) {
     return func_001F3A20(arg0, 6);
 }
 
@@ -253,14 +253,14 @@ void func_001F4810(XKitten* arg0, XKitten* arg1) {
     arg1->next = kit1_next;
 }
 
-XLaserDot* func_001F4858(XKitten* arg0) {
+u8* func_001F4858(XKitten* arg0) {
     if (arg0->unk_5C == NULL) {
         return &D_0048A670;
     }
     return arg0->unk_5C;
 }
 
-void func_001F4878(XKitten* arg0, XLaserDot* arg1) {
+void func_001F4878(XKitten* arg0, u8* arg1) {
     arg0->unk_5C = arg1;
 }
 

--- a/src/xtailor.c
+++ b/src/xtailor.c
@@ -275,8 +275,11 @@ void func_00110C40(f32 arg0, f32 arg1, f32 arg2, f32 arg3) {
 
 INCLUDE_ASM(const s32, "xtailor", func_00110C70);
 
-INCLUDE_ASM(const s32, "xtailor", func_00110DE0);
-void func_00110DE0();
+void func_00110DE0() {
+    D_002B9030 = 1;
+    FlushCache(2);
+    func_F20000(0, D_004D2994);
+}
 
 void func_00110E18(void) {
     D_002A30D0 = 0;


### PR DESCRIPTION
Xmeowp, previously interpreted as helper functions for some structure that implements a doubly linked list, appears to be commonly used in conjunction with the memcard functions recently decompiled. This PR aims to standardize what I wrote in that many months ago more towards the typical naming convention of the project and set up a header file to accommodate its usage in other files. As a bonus I matched a couple random functions and tidied xbiscuit slightly. 